### PR TITLE
특정 위치 근처의 반려견 시설 구하기 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '6.2.5.Final'
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/petdori/apiserver/domain/facility/controller/PetFacilityController.java
+++ b/src/main/java/petdori/apiserver/domain/facility/controller/PetFacilityController.java
@@ -21,7 +21,7 @@ public class PetFacilityController {
     @GetMapping("/nearby-facilities")
     private BaseResponse<List<NearbyFacilityResponseDto>> test(
             @RequestBody NearbyFacilityRequestDto nearbyFacilityRequestDto,
-            @RequestParam("keyword") String[] keywords
+            @RequestParam(value = "keyword", required = false) String[] keywords
             ) {
         List<NearbyFacilityResponseDto> nearByFacilities = petFacilityService.getNearByFacilities(nearbyFacilityRequestDto, keywords);
         return BaseResponse.createSuccessResponse(nearByFacilities);

--- a/src/main/java/petdori/apiserver/domain/facility/controller/PetFacilityController.java
+++ b/src/main/java/petdori/apiserver/domain/facility/controller/PetFacilityController.java
@@ -1,0 +1,29 @@
+package petdori.apiserver.domain.facility.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.*;
+import petdori.apiserver.domain.facility.dto.request.NearbyFacilityRequestDto;
+import petdori.apiserver.domain.facility.dto.response.NearbyFacilityResponseDto;
+import petdori.apiserver.domain.facility.service.PetFacilityService;
+import petdori.apiserver.global.common.BaseResponse;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/facility")
+public class PetFacilityController {
+    private final PetFacilityService petFacilityService;
+
+    @GetMapping("/nearby-facilities")
+    private BaseResponse<List<NearbyFacilityResponseDto>> test(
+            @RequestBody NearbyFacilityRequestDto nearbyFacilityRequestDto,
+            @RequestParam("keyword") String[] keywords
+            ) {
+        List<NearbyFacilityResponseDto> nearByFacilities = petFacilityService.getNearByFacilities(nearbyFacilityRequestDto, keywords);
+        return BaseResponse.createSuccessResponse(nearByFacilities);
+    }
+}

--- a/src/main/java/petdori/apiserver/domain/facility/controller/PetFacilityController.java
+++ b/src/main/java/petdori/apiserver/domain/facility/controller/PetFacilityController.java
@@ -19,7 +19,7 @@ public class PetFacilityController {
     private final PetFacilityService petFacilityService;
 
     @GetMapping("/nearby-facilities")
-    private BaseResponse<List<NearbyFacilityResponseDto>> test(
+    private BaseResponse<List<NearbyFacilityResponseDto>> getNearbyFacilities(
             @RequestBody NearbyFacilityRequestDto nearbyFacilityRequestDto,
             @RequestParam(value = "keyword", required = false) String[] keywords
             ) {

--- a/src/main/java/petdori/apiserver/domain/facility/dto/request/NearbyFacilityRequestDto.java
+++ b/src/main/java/petdori/apiserver/domain/facility/dto/request/NearbyFacilityRequestDto.java
@@ -1,0 +1,15 @@
+package petdori.apiserver.domain.facility.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class NearbyFacilityRequestDto {
+    // 위도
+    private double latitude;
+    // 경도
+    private double longitude;
+    // 반경 (단위 : m)
+    private Long radius;
+}

--- a/src/main/java/petdori/apiserver/domain/facility/dto/response/FacilityTypeNotExistResponseDto.java
+++ b/src/main/java/petdori/apiserver/domain/facility/dto/response/FacilityTypeNotExistResponseDto.java
@@ -1,4 +1,4 @@
-package petdori.apiserver.domain.dog.dto.response;
+package petdori.apiserver.domain.facility.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Builder
 @Getter
-public class DogTypeNotExistResponseDto {
+public class FacilityTypeNotExistResponseDto {
     @JsonProperty("type_name")
     private String typeName;
 }

--- a/src/main/java/petdori/apiserver/domain/facility/dto/response/NearbyFacilityResponseDto.java
+++ b/src/main/java/petdori/apiserver/domain/facility/dto/response/NearbyFacilityResponseDto.java
@@ -1,5 +1,6 @@
 package petdori.apiserver.domain.facility.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,8 @@ public class NearbyFacilityResponseDto {
     private String address;
     private double latitude;
     private double longitude;
+    @JsonProperty("distance_info")
     private String distanceInfo;
+    @JsonProperty("operating_hour_info")
     private String operatingHourInfo;
 }

--- a/src/main/java/petdori/apiserver/domain/facility/dto/response/NearbyFacilityResponseDto.java
+++ b/src/main/java/petdori/apiserver/domain/facility/dto/response/NearbyFacilityResponseDto.java
@@ -1,0 +1,15 @@
+package petdori.apiserver.domain.facility.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class NearbyFacilityResponseDto {
+    private String name;
+    private String address;
+    private double latitude;
+    private double longitude;
+    private String distanceInfo;
+    private String operatingHourInfo;
+}

--- a/src/main/java/petdori/apiserver/domain/facility/entity/DayOfTheWeek.java
+++ b/src/main/java/petdori/apiserver/domain/facility/entity/DayOfTheWeek.java
@@ -1,0 +1,15 @@
+package petdori.apiserver.domain.facility.entity;
+
+public enum DayOfTheWeek {
+    SUN("일"), MON("월"), TUE("화"), WED("수"), THU("목"), FRI("금"), SAT("토");
+
+    private final String value;
+
+    DayOfTheWeek(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/petdori/apiserver/domain/facility/entity/PetFacility.java
+++ b/src/main/java/petdori/apiserver/domain/facility/entity/PetFacility.java
@@ -1,0 +1,37 @@
+package petdori.apiserver.domain.facility.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.locationtech.jts.geom.Point;
+import petdori.apiserver.global.common.BaseTimeEntity;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE pet_facility SET deleted_date = NOW() WHERE id = ?")
+@Builder
+@Getter
+@Entity
+public class PetFacility extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @OneToOne
+    @JoinColumn(name = "pet_facility_type_id", nullable = false)
+    private PetFacilityType petFacilityType;
+
+    @Column(nullable = false, columnDefinition = "POINT")
+    private Point location;
+
+    @Column(nullable = false, length = 255)
+    private String address;
+
+    @OneToMany(mappedBy = "petFacility", cascade = CascadeType.ALL)
+    private List<PetFacilityOperatingHour> operatingHours;
+}

--- a/src/main/java/petdori/apiserver/domain/facility/entity/PetFacilityOperatingHour.java
+++ b/src/main/java/petdori/apiserver/domain/facility/entity/PetFacilityOperatingHour.java
@@ -1,0 +1,33 @@
+package petdori.apiserver.domain.facility.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import java.sql.Time;
+import java.time.LocalTime;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE pet_facility_operating_hour SET deleted_date = NOW() WHERE id = ?")
+@Builder
+@Getter
+@Entity
+public class PetFacilityOperatingHour {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_facility_id", nullable = false)
+    private PetFacility petFacility;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DayOfTheWeek dayOfTheWeek;
+
+    @Column(nullable = false, columnDefinition = "TIME")
+    private String openHour;
+
+    @Column(nullable = false, columnDefinition = "TIME")
+    private String closeHour;
+}

--- a/src/main/java/petdori/apiserver/domain/facility/entity/PetFacilityType.java
+++ b/src/main/java/petdori/apiserver/domain/facility/entity/PetFacilityType.java
@@ -1,0 +1,18 @@
+package petdori.apiserver.domain.facility.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.SQLDelete;
+import petdori.apiserver.global.common.BaseTimeEntity;
+
+@SQLDelete(sql = "UPDATE pet_facility_type SET deleted_date = NOW() WHERE id = ?")
+@Getter
+@Entity
+public class PetFacilityType extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 45, unique = true)
+    private String typeName;
+}

--- a/src/main/java/petdori/apiserver/domain/facility/exception/FacilityErrorCode.java
+++ b/src/main/java/petdori/apiserver/domain/facility/exception/FacilityErrorCode.java
@@ -1,0 +1,14 @@
+package petdori.apiserver.domain.facility.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum FacilityErrorCode {
+    FACILITY_TYPE_NOT_EXIST(HttpStatus.NOT_FOUND, "등록되지 않은 시설 종류입니다");
+
+    private HttpStatus httpStatus;
+    private String errorMessage;
+}

--- a/src/main/java/petdori/apiserver/domain/facility/exception/FacilityException.java
+++ b/src/main/java/petdori/apiserver/domain/facility/exception/FacilityException.java
@@ -1,0 +1,13 @@
+package petdori.apiserver.domain.facility.exception;
+
+import lombok.Getter;
+
+@Getter
+public class FacilityException extends RuntimeException {
+    private final FacilityErrorCode facilityErrorCode;
+
+    public FacilityException(FacilityErrorCode facilityErrorCode) {
+        super(facilityErrorCode.getErrorMessage());
+        this.facilityErrorCode = facilityErrorCode;
+    }
+}

--- a/src/main/java/petdori/apiserver/domain/facility/exception/FacilityTypeNotExistException.java
+++ b/src/main/java/petdori/apiserver/domain/facility/exception/FacilityTypeNotExistException.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public class FacilityTypeNotExistException extends FacilityException {
-    private String typeName;
+    private final String typeName;
 
     public FacilityTypeNotExistException(String typeName) {
         super(FacilityErrorCode.FACILITY_TYPE_NOT_EXIST);

--- a/src/main/java/petdori/apiserver/domain/facility/exception/FacilityTypeNotExistException.java
+++ b/src/main/java/petdori/apiserver/domain/facility/exception/FacilityTypeNotExistException.java
@@ -1,0 +1,13 @@
+package petdori.apiserver.domain.facility.exception;
+
+import lombok.Getter;
+
+@Getter
+public class FacilityTypeNotExistException extends FacilityException {
+    private String typeName;
+
+    public FacilityTypeNotExistException(String typeName) {
+        super(FacilityErrorCode.FACILITY_TYPE_NOT_EXIST);
+        this.typeName = typeName;
+    }
+}

--- a/src/main/java/petdori/apiserver/domain/facility/repository/PetFacilityOperatingHourRepository.java
+++ b/src/main/java/petdori/apiserver/domain/facility/repository/PetFacilityOperatingHourRepository.java
@@ -1,0 +1,9 @@
+package petdori.apiserver.domain.facility.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import petdori.apiserver.domain.facility.entity.PetFacilityOperatingHour;
+import java.util.List;
+
+public interface PetFacilityOperatingHourRepository extends JpaRepository<PetFacilityOperatingHour, Long> {
+    List<PetFacilityOperatingHour> findByPetFacilityId(Long petFacilityId);
+}

--- a/src/main/java/petdori/apiserver/domain/facility/repository/PetFacilityRepository.java
+++ b/src/main/java/petdori/apiserver/domain/facility/repository/PetFacilityRepository.java
@@ -1,0 +1,26 @@
+package petdori.apiserver.domain.facility.repository;
+
+import org.geolatte.geom.Point;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import petdori.apiserver.domain.facility.entity.PetFacility;
+
+import java.util.List;
+
+public interface PetFacilityRepository extends JpaRepository<PetFacility, Long> {
+    @Query(value = "SELECT id, name, address, location, ST_Distance_Sphere(location, ST_GeomFromText(CONCAT('POINT(', ?1, ' ', ?2, ')'))) as 'distance'\n" +
+            "FROM pet_facility\n" +
+            "WHERE ST_Distance_Sphere(location, ST_GeomFromText(CONCAT('POINT(', ?1, ' ', ?2, ')'))) <= ?3 AND pet_facility_type_id IN ?4 \n" +
+            "ORDER BY distance\n" +
+            "LIMIT 15",
+            nativeQuery = true)
+    List<NearByFacilityInfo> findByDistance(double longitude, double latitude, double radius, List<Long> filteredTypeIds);
+
+    interface NearByFacilityInfo {
+        Long getId();
+        String getName();
+        String getAddress();
+        Point getLocation();
+        double getDistance();
+    }
+}

--- a/src/main/java/petdori/apiserver/domain/facility/repository/PetFacilityTypeRepository.java
+++ b/src/main/java/petdori/apiserver/domain/facility/repository/PetFacilityTypeRepository.java
@@ -1,0 +1,9 @@
+package petdori.apiserver.domain.facility.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import petdori.apiserver.domain.facility.entity.PetFacilityType;
+import java.util.Optional;
+
+public interface PetFacilityTypeRepository extends JpaRepository<PetFacilityType, Long> {
+    Optional<PetFacilityType> findIdByTypeName(String typeName);
+}

--- a/src/main/java/petdori/apiserver/domain/facility/service/PetFacilityService.java
+++ b/src/main/java/petdori/apiserver/domain/facility/service/PetFacilityService.java
@@ -1,0 +1,101 @@
+package petdori.apiserver.domain.facility.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import petdori.apiserver.domain.facility.dto.request.NearbyFacilityRequestDto;
+import petdori.apiserver.domain.facility.dto.response.NearbyFacilityResponseDto;
+import petdori.apiserver.domain.facility.entity.PetFacilityOperatingHour;
+import petdori.apiserver.domain.facility.entity.PetFacilityType;
+import petdori.apiserver.domain.facility.repository.PetFacilityOperatingHourRepository;
+import petdori.apiserver.domain.facility.repository.PetFacilityRepository;
+import petdori.apiserver.domain.facility.repository.PetFacilityRepository.NearByFacilityInfo;
+import petdori.apiserver.domain.facility.repository.PetFacilityTypeRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+@Service
+public class PetFacilityService {
+    private final PetFacilityRepository petFacilityRepository;
+    private final PetFacilityOperatingHourRepository petFacilityOperatingHourRepository;
+    private final PetFacilityTypeRepository petFacilityTypeRepository;
+
+    public List<NearbyFacilityResponseDto> getNearByFacilities(
+            NearbyFacilityRequestDto nearbyFacilityRequestDto,
+            String[] keywords
+    ) {
+        List<Long> filteredTypeIds = new ArrayList<>();
+        for (String typeName : keywords) {
+            Long typeId = petFacilityTypeRepository.findIdByTypeName(typeName)
+                    .orElseThrow().getId();
+            filteredTypeIds.add(typeId);
+        }
+
+        double currentLatitude = nearbyFacilityRequestDto.getLatitude();
+        double currentLongitude = nearbyFacilityRequestDto.getLongitude();
+        double radius = nearbyFacilityRequestDto.getRadius();
+
+        List<NearByFacilityInfo> nearByFacilityInfos = petFacilityRepository
+                .findByDistance(currentLongitude, currentLatitude, radius, filteredTypeIds);
+        List<NearbyFacilityResponseDto> nearbyFacilities = new ArrayList<>();
+
+        for (NearByFacilityInfo nearByFacilityInfo : nearByFacilityInfos) {
+            Long petFacilityId = nearByFacilityInfo.getId();
+            double latitude = nearByFacilityInfo.getLocation().getPosition().getCoordinate(1);
+            double longitude = nearByFacilityInfo.getLocation().getPosition().getCoordinate(0);
+            NearbyFacilityResponseDto nearbyFacilityResponseDto = NearbyFacilityResponseDto.builder()
+                    .name(nearByFacilityInfo.getName())
+                    .address(nearByFacilityInfo.getAddress())
+                    .latitude(latitude)
+                    .longitude(longitude)
+                    .distanceInfo(convertDistance(nearByFacilityInfo.getDistance()))
+                    .operatingHourInfo(getOperatingHourInfo(petFacilityId))
+                    .build();
+            nearbyFacilities.add(nearbyFacilityResponseDto);
+        }
+
+        return nearbyFacilities;
+    }
+
+    private String convertDistance(double distance) {
+        if (distance < 1000) {
+            return String.format("%.0f", distance) + "m";
+        }
+        return String.format("%.2f", distance / 1000) + "km";
+    }
+
+    private String getOperatingHourInfo(Long petFacilityId) {
+        List<PetFacilityOperatingHour> operatingHours = petFacilityOperatingHourRepository.findByPetFacilityId(petFacilityId);
+        StringBuffer operatingInfoBuffer = new StringBuffer();
+            if (operatingHours.size() > 0) {
+                String openHour = operatingHours.get(0).getOpenHour().substring(0, 5);
+                String closeHour = operatingHours.get(0).getCloseHour().substring(0, 5);
+                if (operatingHours.size() == 7) {
+                    operatingInfoBuffer.append("매일 ")
+                            .append(openHour)
+                            .append(" ~ ")
+                            .append(closeHour);
+                } else{
+                    for (int i=0; i < operatingHours.size(); i++) {
+                        PetFacilityOperatingHour operatingHour = operatingHours.get(i);
+                        operatingInfoBuffer.append(operatingHour.getDayOfTheWeek().getValue());
+                        if (i != operatingHours.size() - 1) {
+                            operatingInfoBuffer.append(",");
+                        }
+                    }
+                    operatingInfoBuffer.append(" ")
+                            .append(openHour)
+                            .append(" ~ ")
+                            .append(closeHour);
+                }
+            }
+        return operatingInfoBuffer.toString();
+    }
+}

--- a/src/main/java/petdori/apiserver/domain/facility/service/PetFacilityService.java
+++ b/src/main/java/petdori/apiserver/domain/facility/service/PetFacilityService.java
@@ -32,6 +32,11 @@ public class PetFacilityService {
             NearbyFacilityRequestDto nearbyFacilityRequestDto,
             String[] keywords
     ) {
+        // keyword라는 이름의 쿼리스트링으로 전달받은 값이 하나도 없을 경우 빈 리스트를 반환
+        if (keywords == null) {
+            return new ArrayList<>();
+        }
+
         List<Long> filteredTypeIds = new ArrayList<>();
         for (String typeName : keywords) {
             Long typeId = petFacilityTypeRepository.findIdByTypeName(typeName)

--- a/src/main/java/petdori/apiserver/domain/facility/service/PetFacilityService.java
+++ b/src/main/java/petdori/apiserver/domain/facility/service/PetFacilityService.java
@@ -82,7 +82,7 @@ public class PetFacilityService {
     private String getOperatingHourInfo(Long petFacilityId) {
         List<PetFacilityOperatingHour> operatingHours = petFacilityOperatingHourRepository.findByPetFacilityId(petFacilityId);
         StringBuffer operatingInfoBuffer = new StringBuffer();
-            if (operatingHours.size() > 0) {
+            if (!operatingHours.isEmpty()) {
                 String openHour = operatingHours.get(0).getOpenHour().substring(0, 5);
                 String closeHour = operatingHours.get(0).getCloseHour().substring(0, 5);
                 if (operatingHours.size() == 7) {

--- a/src/main/java/petdori/apiserver/domain/facility/service/PetFacilityService.java
+++ b/src/main/java/petdori/apiserver/domain/facility/service/PetFacilityService.java
@@ -8,6 +8,7 @@ import petdori.apiserver.domain.facility.dto.request.NearbyFacilityRequestDto;
 import petdori.apiserver.domain.facility.dto.response.NearbyFacilityResponseDto;
 import petdori.apiserver.domain.facility.entity.PetFacilityOperatingHour;
 import petdori.apiserver.domain.facility.entity.PetFacilityType;
+import petdori.apiserver.domain.facility.exception.FacilityTypeNotExistException;
 import petdori.apiserver.domain.facility.repository.PetFacilityOperatingHourRepository;
 import petdori.apiserver.domain.facility.repository.PetFacilityRepository;
 import petdori.apiserver.domain.facility.repository.PetFacilityRepository.NearByFacilityInfo;
@@ -34,7 +35,9 @@ public class PetFacilityService {
         List<Long> filteredTypeIds = new ArrayList<>();
         for (String typeName : keywords) {
             Long typeId = petFacilityTypeRepository.findIdByTypeName(typeName)
-                    .orElseThrow().getId();
+                    .orElseThrow(
+                            () -> new FacilityTypeNotExistException(typeName)
+                    ).getId();
             filteredTypeIds.add(typeId);
         }
 

--- a/src/main/java/petdori/apiserver/global/exception/PetdoriExceptionHandler.java
+++ b/src/main/java/petdori/apiserver/global/exception/PetdoriExceptionHandler.java
@@ -5,6 +5,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import petdori.apiserver.domain.auth.exception.member.MemberException;
+import petdori.apiserver.domain.facility.dto.response.FacilityTypeNotExistResponseDto;
+import petdori.apiserver.domain.facility.exception.FacilityTypeNotExistException;
 import petdori.apiserver.global.common.BaseResponse;
 import petdori.apiserver.domain.auth.exception.oauth2.Oauth2Exception;
 import petdori.apiserver.domain.auth.exception.token.CustomJwtException;
@@ -18,7 +20,7 @@ import petdori.apiserver.domain.auth.exception.member.MemberNotExistException;
 
 @Slf4j
 @ControllerAdvice
-public class WYSExceptionHandler {
+public class PetdoriExceptionHandler {
     @ExceptionHandler(MemberNotExistException.class)
     public ResponseEntity<BaseResponse<?>> handleMemberNotExistException(MemberNotExistException ex) {
         String email = ex.getEmail();
@@ -89,6 +91,21 @@ public class WYSExceptionHandler {
         return ResponseEntity.status(ex.getOauth2ErrorCode().getHttpStatus())
                 .body(BaseResponse.createErrorResponseWithNoContent(
                         "알 수 없는 이유로 로그인에 실패했습니다. 다시 시도해주세요"
+                ));
+    }
+
+    @ExceptionHandler(FacilityTypeNotExistException.class)
+    public ResponseEntity<BaseResponse<?>> handleFacilityTypeNotExistException(FacilityTypeNotExistException ex) {
+        String typeName = ex.getTypeName();
+        FacilityTypeNotExistResponseDto facilityTypeNotExistResponseDto =
+                FacilityTypeNotExistResponseDto.builder()
+                .typeName(typeName)
+                .build();
+
+        return ResponseEntity.status(ex.getFacilityErrorCode().getHttpStatus())
+                .body(BaseResponse.createErrorResponse(
+                        facilityTypeNotExistResponseDto,
+                        ex.getFacilityErrorCode().getErrorMessage()
                 ));
     }
 }


### PR DESCRIPTION
## 📌 PR summary
- 특정 위치 근처의 반려견 시설을 조회하는 기능 구현

## 💫 Changes
- 특정 위치 근처의 반라견 시설 조회하는 기능 구현(현재 Hibernate에서 MySQL 관련한 거리계산 함수를 지원하지 않아 Native Query 사용)
    - 거리는 1000m보다 적으면 OOOm, 1000m 이상이면 O.Okm으로 표기하도록 구현
    - 영업시간도 컨버팅해 반환하도록 구현 
- 사용자가 필터링한 키워드를 반영해 조회하도록 함
    - `/api/facility/nearby-facilities?keyword=동물병원&keyword=애견숙소` 와 같이
    - keyword를 쿼리스트링으로 전달하지 않을 시 어떠한 시설정보도 반환하지 않도록 함
    - keyword로 잘못된 값(ex: 동말병원)을 전달할 경우에 대한 예외처리도 구현

## 📱 Screenshots. 
- 성공한 경우
![image](https://github.com/SWmaestro-14th-somsatang/petdori-api-server/assets/65762283/3b11c4d9-d751-4539-aee8-2bfbb9f970dc)

- 실패한 경우  
![image](https://github.com/SWmaestro-14th-somsatang/petdori-api-server/assets/65762283/85e7831d-c3e6-4319-bd99-d5b37ea50387)


## ⚠️ Related Issue
Related [#7 ]

## 📃 ETC
- 현재 조회 속도가 평균적으로 300 ~ 500ms가 걸리며, 좀 더 빨리 할 수 있는 방법을 찾아봐야 함.
