### PR TITLE
spatial index 적용에 따른 native query 수정

### DIFF
--- a/src/main/java/petdori/apiserver/domain/facility/entity/PetFacility.java
+++ b/src/main/java/petdori/apiserver/domain/facility/entity/PetFacility.java
@@ -26,7 +26,7 @@ public class PetFacility extends BaseTimeEntity {
     @JoinColumn(name = "pet_facility_type_id", nullable = false)
     private PetFacilityType petFacilityType;
 
-    @Column(nullable = false, columnDefinition = "POINT")
+    @Column(nullable = false, columnDefinition = "POINT SRID 4326")
     private Point location;
 
     @Column(nullable = false, length = 255)

--- a/src/main/java/petdori/apiserver/domain/facility/repository/PetFacilityRepository.java
+++ b/src/main/java/petdori/apiserver/domain/facility/repository/PetFacilityRepository.java
@@ -8,13 +8,13 @@ import petdori.apiserver.domain.facility.entity.PetFacility;
 import java.util.List;
 
 public interface PetFacilityRepository extends JpaRepository<PetFacility, Long> {
-    @Query(value = "SELECT id, name, address, location, ST_Distance_Sphere(location, ST_GeomFromText(CONCAT('POINT(', ?1, ' ', ?2, ')'))) as 'distance'\n" +
+    @Query(value = "SELECT id, name, address, location, ST_Distance_Sphere(location, ST_GeomFromText(CONCAT('POINT(', ?1, ' ', ?2, ')'), 4326)) as 'distance'\n" +
             "FROM pet_facility\n" +
-            "WHERE ST_Distance_Sphere(location, ST_GeomFromText(CONCAT('POINT(', ?1, ' ', ?2, ')'))) <= ?3 AND pet_facility_type_id IN ?4 \n" +
+            "WHERE ST_Contains(ST_Buffer(ST_GeomFromText(CONCAT('POINT(', ?1, ' ', ?2, ')'), 4326), ?3), location) AND pet_facility_type_id IN ?4 \n" +
             "ORDER BY distance\n" +
             "LIMIT 15",
             nativeQuery = true)
-    List<NearByFacilityInfo> findByDistance(double longitude, double latitude, double radius, List<Long> filteredTypeIds);
+    List<NearByFacilityInfo> findByDistance(double latitude, double longitude, double radius, List<Long> filteredTypeIds);
 
     interface NearByFacilityInfo {
         Long getId();

--- a/src/main/java/petdori/apiserver/domain/facility/service/PetFacilityService.java
+++ b/src/main/java/petdori/apiserver/domain/facility/service/PetFacilityService.java
@@ -51,7 +51,7 @@ public class PetFacilityService {
         double radius = nearbyFacilityRequestDto.getRadius();
 
         List<NearByFacilityInfo> nearByFacilityInfos = petFacilityRepository
-                .findByDistance(currentLongitude, currentLatitude, radius, filteredTypeIds);
+                .findByDistance(currentLatitude, currentLongitude, radius, filteredTypeIds);
         List<NearbyFacilityResponseDto> nearbyFacilities = new ArrayList<>();
 
         for (NearByFacilityInfo nearByFacilityInfo : nearByFacilityInfos) {


### PR DESCRIPTION
## 📌 PR summary
- Spatial Index 적용에 따른 native query 수정

## 💫 Changes
- Spatial Index 적용에 따른 native query 수정
    - SRID를 4326를 쓰도록 수정
    - ST_Distance_Sphere가 아닌 ST_Contains를 사용하도록 수정

## 📱 Screenshots
x

## ⚠️ Related Issue
Related [이슈번호]

## 📃 ETC
- ST_Contains 또는 ST_Within을 사용해야 Spatial Index 적용의 효과를 얻을 수 있음
- ST_Contains나 ST_Within을 Spatial Index 없이 사용하는 것과 Spatial Index가 있는채로 사용하는 것은 분명한 성능차이 존재(약 5배 이상의 차이가 존재)
- 그러나 1) ST_Distance_Sphere를 쓰는 것과 2) Spatial Index가 있는 채로 ST_Contains를 쓰는 것은 현재 엄청난 차이가 있지는 않음(후자가 좀 더 빠르긴 함)
    - 전자는 풀스캔 방식이고 후자는 인덱스를 사용하는 건데, 현재 데이터가 5,000개 정도로 적은 편이라 차이가 크지 않은 듯
    - 그러나 데이터가 많아질수록 인덱스 사용이 유리할 것이라 판단됨
