### PR TITLE
빈 List 체크 방식 변경

### DIFF
--- a/src/main/java/petdori/apiserver/domain/auth/oauth2/apple/ApplePublicKeyGenerator.java
+++ b/src/main/java/petdori/apiserver/domain/auth/oauth2/apple/ApplePublicKeyGenerator.java
@@ -61,7 +61,7 @@ public class ApplePublicKeyGenerator {
     }
 
     private JSONObject findMatchedPublicKeyObj(JSONArray availablePublicKeyObjects, String alg, String kid) {
-        if (availablePublicKeyObjects == null || availablePublicKeyObjects.size() == 0) {
+        if (availablePublicKeyObjects == null || availablePublicKeyObjects.isEmpty()) {
             throw new AppleKeyInfoNotReceivedException();
         }
 


### PR DESCRIPTION
## 📌 PR summary
- 빈 List 체크 방식 변경

## 💫 Changes
- ApplePublicKeyGenerator.findMatchedPublicJeyObj에서 size() == 0으로 체크하던 것을 isEmpty를 사용하도록 변경

## 📱 Screenshots
x

## ⚠️ Related Issue
Related [#23 ]

## 📃 ETC
x
